### PR TITLE
Feature UI

### DIFF
--- a/static/css/statistics.css
+++ b/static/css/statistics.css
@@ -1,0 +1,216 @@
+:root{
+	--bg:#f6f9ff;          
+	--surface:#ffffff;
+	--border:#e8eef7;
+	--muted:#8a94a7;
+	--text:#24324a;
+	--accent:#3b82f6;
+	--accent2:#b8c3d9;
+	--good:#10b981;
+	--danger:#ef4444;
+	--radius:18px;
+	--shadow:0 12px 32px rgba(43,71,140,.12);
+}
+
+*{
+	box-sizing:border-box
+}
+
+body{
+	margin:0; 
+	background:var(--bg); 
+	color:var(--text);
+	font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,"Apple SD Gothic Neo","Noto Sans KR","맑은 고딕",Arial,Helvetica,sans-serif;
+}
+
+/* 헤더: 좌측 링크, 우측 사용자/로그아웃 */
+.topbar{
+	display:flex; 
+	align-items:center; 
+	justify-content:space-between;
+	padding:18px 20px 10px;
+}
+.brand-link{
+	font-weight:800; 
+	color:#1f2a44; 
+	text-decoration:none;
+}
+.topbar .right{
+	display:flex; 
+	align-items:center; 
+	gap:10px
+}
+.user{
+	color:#1f2a44; 
+	font-weight:700
+}
+.logout{
+	color:#64748b; 
+	text-decoration:none; 
+	font-weight:600
+}
+
+.tabs{
+	display:flex; 
+	gap:10px; 
+	justify-content:center; 
+	flex-wrap:wrap;
+	padding:8px 16px 16px;
+}
+.tab{
+	background:#fff; 
+	color:#4b5563; 
+	border:1px solid var(--border); 
+	border-radius:999px;
+	padding:10px 14px; 
+	font-size:14px; 
+	cursor:pointer;
+	box-shadow:0 4px 10px rgba(28,44,80,.06)
+}
+.tab.active{	
+	background:var(--accent); 
+	color:#fff; 
+	border-color:transparent
+}
+
+.wrap{
+	max-width:980px; 
+	margin:0 auto; 
+	padding:0 16px 64px
+}
+.card{
+	background:var(--surface);
+	border:1px solid var(--border);
+	border-radius:var(--radius); 
+	box-shadow:var(--shadow);
+	padding:22px; 
+	margin:14px auto;
+}
+.card.narrow{
+	max-width:760px
+}
+.card h3{
+	margin:0 0 8px; 
+	font-size:18px; 
+	font-weight:800
+}
+.sub{	
+	color:var(--muted); 
+	font-size:13px
+}
+.small{
+	font-size:12px
+}
+
+/* KPI */
+.kpi{
+	display:flex; 
+	align-items:baseline; 
+	gap:12px; 
+	margin-top:10px}
+.kpi .big{
+	font-weight:800; 
+	font-size:22px
+}
+.kpi .delta{
+	font-size:13px; 
+	color:var(--danger)
+}
+
+/* charts */
+.chart{
+	width:100%; 
+	height:220px; 
+	margin-top:12px
+}
+svg{
+	width:100%; 
+	height:100%; 
+	display:block
+}
+.grid line{
+	stroke:#eef2fb; 
+	stroke-width:1
+}
+.axis text{
+	fill:#9aa6bd; 
+	font-size:11px
+}
+.legend{
+	display:flex; 
+	gap:18px; 
+	color:#6b7280; 
+	font-size:12px; 
+	margin-top:10px
+}
+.legend .box{
+	width:18px; 
+	height:4px; 
+	border-radius:3px; 
+	display:inline-block; 
+	vertical-align:middle; 
+	margin-right:6px
+}
+.legend .box.primary{
+	background:var(--accent)
+}
+.legend .box.grey{
+	background:var(--accent2)
+}
+
+/* pills */
+.pills .pill{
+	background:#f1f6ff; 
+	border:1px solid var(--border); 
+	color:#3a4a6a;
+	padding:8px 10px; 
+	border-radius:12px; 
+	font-size:12px; 
+	margin:6px 6px 0 0; 
+	display:inline-block
+}
+
+/* balance card */
+.card-head{
+	display:flex; 
+	align-items:baseline; 
+	justify-content:space-between; 
+	margin-bottom:8px
+}
+.balance-grid{
+	display:grid; 
+	gap:12px; 
+	margin-top:8px
+}
+.row{
+	display:flex; 
+	align-items:center; 
+	justify-content:space-between; 
+	padding:6px 0; 
+	border-bottom:1px dashed #edf2ff
+}
+.row:last-child{
+	border-bottom:none
+}
+.row.indent{
+	padding-left:16px
+}
+.label{
+	color:#475569; 
+	font-weight:700
+}
+.val{
+	font-weight:700
+}
+.total .label{
+	font-weight:800
+}
+.remain{
+	color:#2563eb
+}
+.muted{
+	color:var(--muted)
+}
+.hidden{
+	display:none
+}

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -1,0 +1,135 @@
+// statistics.js (정리본)
+console.log('statistics.js loaded');
+
+(function () {
+	// ---------- Helpers ----------
+	const won = n => (Math.round(n)).toLocaleString('ko-KR') + '원';
+	const sum = a => a.reduce((x,y)=>x+y,0);
+
+	// ---------- State ----------
+	const defaultState = {
+		monthDaysLabels: Array.from({length:30}, (_,i)=> `${i+1}일`),
+		monthThis: [0,12000,24000,38000,42000,54000,60000,71000,82000,86000,90000,97000,98000,101000,103000,108000,112000,118000,121000,127000,130000,133000,138000,142000,149000,153000,158000,165000,171000,180000],
+		monthPrev:  [0, 8000,14000,19000,25000,29000,32000,37000,41000,43000,47000,50000,54000,59000,62000,64000,69000,73000,77000,80000,83000,86000,90000,94000,98000,100000,103000,106000,109000,112000],
+		monthCats: { "식비":34, "주거/통신":12, "생활용품":8, "의복/미용":7, "건강/문화":8, "교육/육아":4, "교통/차량":14, "경조사/회비":3, "세금/이자":4, "용돈/기타":6 },
+		weeksLabels: Array.from({length:10}, (_,i)=> `${i+1}주`),
+		weeksTotals: [110000, 90000, 120000, 150000, 130000, 170000, 140000, 160000, 155000, 180000],
+		incomeTotal: 568752,
+		expense: { total: 958673, card: 656461, transfer: 302212, other: 0 },
+		};
+	let state = (typeof window.__STATS__ !== 'undefined' && window.__STATS__) || defaultState;
+
+	// ---------- UI binds ----------
+	function bindTabs(){
+		document.querySelectorAll('.tab').forEach(t=>{
+			t.addEventListener('click', ()=>{
+			document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active'));
+			document.querySelectorAll('.panel').forEach(p=>p.classList.add('hidden'));
+			t.classList.add('active');
+			
+			document.getElementById(t.dataset.panel).classList.remove('hidden');
+
+			
+			});
+		});
+	}
+
+	// ---------- Dates ----------
+	function setRanges(){
+		const now = new Date();
+		const yyyy = now.getFullYear();
+		const mm = (now.getMonth()+1).toString().padStart(2,'0');
+		const last = new Date(yyyy, now.getMonth()+1, 0).getDate();
+		document.getElementById('rangeMonthly').textContent = `${yyyy}.${mm}.01 ~ ${yyyy}.${mm}.${last}`;
+		document.getElementById('rangeMonthlySpend').textContent = `${yyyy}.${mm}.01 ~ ${yyyy}.${mm}.${last}`;
+		document.getElementById('balanceAsOf').textContent = `${mm}월 ${last}일 기준`;
+	}
+
+	// ---------- SVG Line Chart ----------
+	function lineChart(el, series, labels){
+		const w = el.clientWidth || 600, h = el.clientHeight||220;
+		const pad = {l:28, r:12, t:12, b:24};
+		const W = Math.max(320,w), H = Math.max(160,h);
+		const NS='http://www.w3.org/2000/svg';
+		el.innerHTML = '';
+		const svg = document.createElementNS(NS,'svg'); svg.setAttribute('viewBox',`0 0 ${W} ${H}`); el.appendChild(svg);
+
+		const ymax = Math.max(1, ...series.flat());
+		const X = i => pad.l + (W-pad.l-pad.r) * (i/(labels.length-1 || 1));
+		const Y = v => pad.t + (H-pad.t-pad.b) * (1 - (v/ymax));
+
+		const grid = document.createElementNS(NS,'g'); grid.setAttribute('class','grid'); svg.appendChild(grid);
+		for(let i=0;i<=5;i++){ const y=pad.t+(H-pad.t-pad.b)*i/5;
+			const ln=document.createElementNS(NS,'line'); ln.setAttribute('x1',pad.l); ln.setAttribute('x2',W-pad.r); ln.setAttribute('y1',y); ln.setAttribute('y2',y); grid.appendChild(ln); }
+
+		const axis=document.createElementNS(NS,'g'); axis.setAttribute('class','axis'); svg.appendChild(axis);
+		const xt=(txt,x)=>{ const t=document.createElementNS(NS,'text'); t.setAttribute('x',x); t.setAttribute('y',H-6); t.setAttribute('text-anchor','middle'); t.textContent=txt; axis.appendChild(t); };
+		xt(labels[0]||'', X(0)); xt(labels[labels.length-1]||'', X(labels.length-1));
+
+		const colors=['var(--accent)','var(--accent2)'];
+		series.forEach((arr,si)=>{
+			const p=document.createElementNS(NS,'path'); let d='';
+			arr.forEach((v,i)=>{ d+=(i?' L ':'M ')+X(i)+' '+Y(v); });
+			p.setAttribute('d',d); p.setAttribute('fill','none'); p.setAttribute('stroke',colors[si%colors.length]); p.setAttribute('stroke-width','3'); p.setAttribute('stroke-linecap','round'); svg.appendChild(p);
+			const dot=document.createElementNS(NS,'circle'); dot.setAttribute('cx',X(arr.length-1)); dot.setAttribute('cy',Y(arr[arr.length-1]||0)); dot.setAttribute('r',4); dot.setAttribute('fill',colors[si%colors.length]); svg.appendChild(dot);
+		});
+	}
+
+  	// ---------- Renderers ----------
+	function renderCharts(){
+		const mt = state.monthThis;
+		document.getElementById('mtSum').textContent = won(mt[mt.length-1]||0);
+		const mtDelta = (mt[mt.length-1]||0) - (mt[mt.length-2]||0);
+		document.getElementById('mtDelta').textContent = (mtDelta>=0?'+':'') + won(mtDelta) + ' (오늘 증감)';
+		lineChart(document.getElementById('chartMonthlyTotal'), [mt], state.monthDaysLabels);
+
+		const ms = state.monthThis, mp = state.monthPrev;
+		const diff = (ms[ms.length-1]||0) - (mp[Math.min(mp.length-1, ms.length-1)]||0);
+		document.getElementById('msSum').textContent = '오늘까지 ' + won(ms[ms.length-1]||0) + ' 썼어요';
+		document.getElementById('msDelta').textContent =
+		diff>=0 ? `지난달보다 ${won(diff)} 더 쓰는 중` : `지난달보다 ${won(-diff)} 덜 쓰는 중`;
+		lineChart(document.getElementById('chartMonthlySpend'), [ms, mp], state.monthDaysLabels);
+
+		const list = document.getElementById('categoryBreak'); list.innerHTML='';
+		Object.entries(state.monthCats).forEach(([k,v])=>{
+			const span=document.createElement('span'); span.className='pill'; span.textContent=`${k} ${v}%`; list.appendChild(span);
+		});
+
+		document.getElementById('wtSum').textContent = won(sum(state.weeksTotals));
+		lineChart(document.getElementById('chartWeekly'), [state.weeksTotals], state.weeksLabels);
+	}
+
+	function renderBalance(){
+		const inc = state.incomeTotal||0;
+		const exp = state.expense?.total||0;
+		const card = state.expense?.card||0;
+		const transfer = state.expense?.transfer||0;
+		const other = state.expense?.other ?? Math.max(0, exp - card - transfer);
+		document.getElementById('incomeTotal').textContent = won(inc);
+		document.getElementById('expenseTotal').textContent = won(exp);
+		document.getElementById('expenseCard').textContent = won(card);
+		document.getElementById('expenseTransfer').textContent = won(transfer);
+		document.getElementById('expenseOther').textContent = won(other);
+		const remain = inc - exp;
+		const el = document.getElementById('remainAmount');
+		el.textContent = (remain>=0?'':'-') + won(Math.abs(remain));
+		el.style.color = remain>=0 ? 'var(--good)' : '#2563eb';
+	}
+
+  	function renderAll(){ setRanges(); renderBalance(); renderCharts(); }
+
+	// ---------- Init (ready 한 번만) ----------
+	function init(){
+		bindTabs();
+		const name = localStorage.getItem('username') || '강지연님';
+		document.getElementById('userName').textContent = name;
+		renderAll();
+		window.addEventListener('resize', renderCharts);
+	}
+
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', init);
+	} else {
+		init();
+	}
+})();

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -29,6 +29,13 @@ console.log('statistics.js loaded');
 			
 			document.getElementById(t.dataset.panel).classList.remove('hidden');
 
+			// balanceCard 표시 여부 제어
+            const balanceCard = document.getElementById("balanceCard");
+            if (t.dataset.panel === "monthlyTotal") {
+                balanceCard.classList.remove("hidden");
+            } else {
+                balanceCard.classList.add("hidden");
+            }
 			
 			});
 		});

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -4,9 +4,106 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>가계부 통계</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/statistics.css') }}">
+    <script src="{{ url_for('static', filename='js/statistics.js') }}"></script>
+
 </head>
 <body>
-    <h1>통계페이지</h1>
+    <!-- 헤더: 좌측 내역 링크, 우측 사용자/로그아웃 -->
+    <header class="topbar">
+        <a class="brand-link" href="/ledger">입출금 내역</a>
+        <div class="right">
+            <span id="userName" class="user">강지연님</span>
+            <a class="logout" href="/login">로그아웃</a>
+        </div>
+    </header>
+
+    <!-- 탭 네비게이션 -->
+    <nav class="tabs" role="tablist">
+        <button class="tab active" data-panel="monthlyTotal">월간 합계</button>
+        <button class="tab" data-panel="monthlySpend">월간 지출</button>
+        <button class="tab" data-panel="weeklyTotal">주간 합계</button>
+    </nav>
+
+    <main class="wrap">
+
+       
+
+        <!-- 월간 합계 -->
+        <section class="card narrow panel" id="monthlyTotal">
+            <h3>이 달의 합계</h3>
+            <div class="sub">기간: <span id="rangeMonthly"></span></div>
+            <div class="kpi">
+                <div class="big" id="mtSum">0원</div>
+                <div class="delta" id="mtDelta"></div>
+            </div>
+            <div class="chart" id="chartMonthlyTotal"></div>
+            <div class="legend"><span><span class="box primary"></span>이번달</span></div>
+        </section>
+
+        <!-- 월간 지출 (지난달과 합치기) -->
+        <section class="card narrow panel hidden" id="monthlySpend">
+            <h3>월간 지출 (지난달과 비교)</h3>
+            <div class="sub">기간: <span id="rangeMonthlySpend"></span></div>
+            <div class="kpi">
+                <div class="big" id="msSum">0원</div>
+                <div class="delta" id="msDelta">지난달보다 0원 더 쓰는 중</div>
+            </div>
+            <div class="chart" id="chartMonthlySpend"></div>
+            <div class="legend">
+                <span><span class="box primary"></span>이번달</span>
+                <span><span class="box grey"></span>지난달</span>
+        </div>
+
+        <div id="categoryBreak" class="pills"></div>
+            <p class="muted small">카테고리 분류: 이번달 지출 비중(%)</p>
+        </section>
+
+        <!-- 주간 합계 -->
+        <section class="card narrow panel hidden" id="weeklyTotal">
+            <h3>주간 합계</h3>
+            <div class="sub">최근 10주</div>
+            <div class="kpi"><div class="big" id="wtSum">0원</div></div>
+            <div class="chart" id="chartWeekly"></div>
+            <div class="legend"><span><span class="box primary"></span>주간 합계</span></div>
+        </section>
+
+         <!-- 이번 달 남은 돈 카드 -->
+         <section class="card narrow" id="balanceCard">
+            <div class="card-head">
+                <h3>이번 달 남은 돈</h3>
+                <div class="sub" id="balanceAsOf">이번 달 기준</div>
+            </div>
+
+            <div class="balance-grid">
+                <div class="row">
+                    <div class="label">수입</div>
+                    <div class="val" id="incomeTotal">0원</div>
+                </div>
+                <div class="row">
+                    <div class="label">소비</div>
+                    <div class="val" id="expenseTotal">0원</div>
+                </div>
+                <div class="row indent">
+                    <div class="label">카드로 쓴 돈</div>
+                    <div class="val" id="expenseCard">0원</div>
+                </div>
+                <div class="row indent">
+                    <div class="label">계좌 이체</div>
+                    <div class="val" id="expenseTransfer">0원</div>
+                </div>
+                <div class="row indent">
+                    <div class="label">페이·기타</div>
+                    <div class="val" id="expenseOther">0원</div>
+                </div>
+                <div class="row total">
+                    <div class="label">남은 금액</div>
+                    <div class="val remain" id="remainAmount">0원</div>
+                </div>
+            </div>
+        </section>
+    </main>
+
 </body>
 </html>


### PR DESCRIPTION
Closes #8 
## 변경 사항 요약
> 사용자가 월간/주간 지출 및 합계 내역, 예산 대비 지출 현황을 확인할 수 있는 통계 페이지 생성

- 월간 합계, 월간 지출, 주간 합계 그래프를 보여주는 버튼(배너)
- 상단 헤더 우측에 사용자 이름과 로그아웃 버튼을, 좌측에는 입/출급 페이지로 이동하는 네비게이션 추가
- 총 3종류의 그래프(월간 합계, 월간 지출, 주간 합계)로 통계자료 시각화
- 각종 통계 값 및 user 정보는 하드 코딩하였음
- 상단 헤더 좌축에 입출급 내역 조회 네비게이션 추가, 우측에 로그인 사용자 정보 및 로그아웃 버튼 추가

<br>

## 상세 설명
1. 예산 대비 지출 현황:  이번 달 수입/ 소비를 총 합해서 나타내고, 남은 금액 표시
2. 월간 합계: 라인 그래프로 표현, 하단에 예산 대비 지출 현황 표시
3. 월간 지출: 라인 그래프로 표현, 지난달 지출 그래프와 합쳐서 제공하고 그래프 아래에 카테고리별 지출 비율을 태그형으로 제공
4. 주간 한계: 라인 그래프로 표현

|추가 파일|설명|
|:---:|---|
|`static/js/statistics.js`|statistics 관련 통계 시각화 처리, 모달 기능 처리 등 js 파일|
|`static/css/statistics.css`|css 파일|

<br>

## 변경 전/후
<img width="718" height="762" alt="Screenshot 2025-10-06 at 7 14 26 PM" src="https://github.com/user-attachments/assets/0dfd9b72-4915-4f13-b152-ee6f212e63e6" />
<img width="720" height="574" alt="Screenshot 2025-10-06 at 7 14 46 PM" src="https://github.com/user-attachments/assets/f576ac6a-50a3-4dba-94d4-7ffad9a1852a" />

<img width="719" height="502" alt="Screenshot 2025-10-06 at 7 14 56 PM" src="https://github.com/user-attachments/assets/0e95de63-b6b2-483a-8103-4ba533d01ba7" />

<br>



## 테스트 방법
app.py 실행 후 http://127.0.0.1:8080/statistics 접속 후 테스트