### PR TITLE
feat(ledger): ledger 페이지 내역 입력 칸 비율 조정 

### DIFF
--- a/modules/ledger.py
+++ b/modules/ledger.py
@@ -252,7 +252,7 @@ def select_recent_weeks(user_id, n_weeks):
 # INSERT, UPDATE, DELETE는 결과를 받아오는 게 아니라서 DictCursor가 필수는 아니지만,
 # 일관성을 위해 둬도 상관없고, 에러 발생 시 롤백 로직이 중요합니다.
 
-def insert_transaction(user_id, date, type, desc, amount, category=None):
+def insert_transaction(user_id, date, transaction_type, desc, amount, category, pay):
     db = None
     cursor = None
     try:

--- a/static/css/ledger.css
+++ b/static/css/ledger.css
@@ -71,7 +71,7 @@
 }
 #input-container form {
     display: flex;
-    gap: 10px;
+    gap: 5px;
     flex-wrap: wrap;
     justify-content: center;
     margin-top: 0;
@@ -85,6 +85,12 @@
 }
 #input-container.centered-prompt #input-title {
     margin-bottom: 0;
+}
+#amount{
+    max-width: 120px;
+}
+#desc{
+    max-width: 170px;
 }
 .month-navigator {
     display: flex;

--- a/static/js/ledger.js
+++ b/static/js/ledger.js
@@ -48,6 +48,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 function updateFormState() {
     const currentType = typeSelect.value; // '입금' 또는 '출금'
 
+    if (currentType === '입금' || currentType === '출금') {
+        typeSelect.style.maxWidth = '70px';
+    } else {
+        typeSelect.style.maxWidth = '';   // 스타일 제거 (원래 CSS로 돌아감)
+    }
+    
     // 1) 카테고리 옵션 새로 그리기
     categorySelect.innerHTML = ''; 
     


### PR DESCRIPTION
## Description
입금/출금 유형 선택에 따라 typeSelect 요소의 스타일(max-width)이 동적으로 변경되도록 로직을 추가했습니다.
유형을 선택하지 않은 경우 기존 스타일로 복구되며, 이는 form의 UI 일관성을 유지하는 데 도움이 됩니다.


## Changes
- updateFormState 내부에 typeSelect.style.maxWidth 조건부 적용 로직 추가
- ‘입금’, ‘출금’ 선택 시 max-width: 70px 적용
- 선택 해제 시 스타일 초기화
- 기존 기능(카테고리 렌더링·지불수단 표시 등)과 충돌 없도록 검증

## Screenshots
<img width="783" height="148" alt="Screenshot 2025-12-01 at 12 28 19 AM" src="https://github.com/user-attachments/assets/03c9b5cb-a53b-492d-bf8d-3dd10d0a14d9" />


<img width="769" height="142" alt="Screenshot 2025-12-01 at 12 28 30 AM" src="https://github.com/user-attachments/assets/c96fd461-70aa-4051-be3f-f891da8a8def" />

<img width="771" height="147" alt="Screenshot 2025-12-01 at 12 28 43 AM" src="https://github.com/user-attachments/assets/94fcf976-8794-49f8-9d0b-aac7774e134c" />

Closes #67 